### PR TITLE
Support specifying separate name of the .so from the package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ before_install:
   - vendor/bin/ci-pecl-install swoole
   # Cache and skip version check
   - vendor/bin/ci-pecl-install swoole skip-update
+  # Cache a package that has a different .so name from the package name
+  - vendor/bin/ci-pecl-install libsodium '' sodium
+  # Cache a specific version of a package (.so name required)
+  - vendor/bin/ci-pecl-install grpc-1.9.0 '' grpc
 ```
 
 See [result](https://travis-ci.org/phwoolcon/ci-pecl-cacher/jobs/303924272#L472).

--- a/bin/ci-pecl-install
+++ b/bin/ci-pecl-install
@@ -12,9 +12,14 @@ function info
 
 MODULE=$1
 SKIP_UPDATE=$2
+SO_NAME=$3
 
 if [[ ! ${MODULE} ]]; then
     error "Module name not specified"
+fi
+
+if [[ ! ${SO_NAME} ]]; then
+  SO_NAME=${MODULE}
 fi
 
 function getExtDir()
@@ -44,9 +49,9 @@ function applyLatestCachedSo()
 info "Preparing variables..."
 PHP_VER=$(getPhpVersion)
 EXT_DIR=$(getExtDir)
-TARGET_SO=${EXT_DIR}/${MODULE}.so
+TARGET_SO=${EXT_DIR}/${SO_NAME}.so
 CACHE_DIR=${HOME}/pecl_cache/${PHP_VER}
-LATEST_SO=${CACHE_DIR}/${MODULE}.so
+LATEST_SO=${CACHE_DIR}/${SO_NAME}.so
 CACHED_VER_FILE=${CACHE_DIR}/${MODULE}.ver
 CACHED_INI_FILE=${CACHE_DIR}/${MODULE}.ini
 
@@ -92,6 +97,6 @@ MODULE_VER=${MODULE_VER_ARRAY[2]}
 cp "${TARGET_SO}" "${LATEST_SO}"
 cp "${TARGET_SO}" "${LATEST_SO}-${MODULE_VER}"
 echo ${MODULE_VER} > "${CACHED_VER_FILE}"
-echo "extension=${MODULE}.so" > ${CACHED_INI_FILE}
+echo "extension=${SO_NAME}.so" > ${CACHED_INI_FILE}
 
 info "Installed ${MODULE} ${MODULE_VER}"


### PR DESCRIPTION
This fixes https://github.com/phwoolcon/ci-pecl-cacher/issues/1 by allowing the name of the extensions .so file to be explicitly specified separately from the package name.

It also fixes a similar issue for packages that just have a differently named .so file from package itself,  such as `libsodium` which has `sodium.so`.